### PR TITLE
cicd: build prs and deploy on develop only

### DIFF
--- a/.github/actions/build.yaml
+++ b/.github/actions/build.yaml
@@ -1,0 +1,6 @@
+jobs:
+  build:
+    steps:
+      - uses: actions/checkout@v2
+      - run: python3 -m pip install -r requirements.txt
+      - run: python3 build.py

--- a/.github/actions/build.yaml
+++ b/.github/actions/build.yaml
@@ -1,6 +1,0 @@
-jobs:
-  build:
-    steps:
-      - uses: actions/checkout@v2
-      - run: python3 -m pip install -r requirements.txt
-      - run: ./vilf build

--- a/.github/actions/build.yaml
+++ b/.github/actions/build.yaml
@@ -3,4 +3,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: python3 -m pip install -r requirements.txt
-      - run: python3 build.py
+      - run: ./vilf build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,5 @@
 name: Build VILF
-on: push
+on: [push, workflow_call]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,7 @@
 name: Test Build VILF
 on:
   pull_request:
-    branches: [ develop ]
+    branches: develop
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,8 +1,8 @@
 name: Build VILF
 on: push
-runs-on: ubuntu-latest
 jobs:
   build:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - run: python3 -m pip install -r requirements.txt

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,10 @@
+name: Build VILF
+on: push
+runs-on: ubuntu-latest
+jobs:
+  build:
+    steps:
+      - uses: actions/checkout@v2
+      - run: python3 -m pip install -r requirements.txt
+      - run: python3 build.py
+

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,10 +1,7 @@
 name: Build VILF
-on: [push, workflow_call]
+on: push
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - run: python3 -m pip install -r requirements.txt
-      - run: python3 build.py
-
+      - uses: ./.github/actions/build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,7 @@
 name: Build VILF
-on: push
+on:
+  pull_request:
+    branches: [ develop ]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: Build VILF
+name: Test Build VILF
 on:
   pull_request:
     branches: [ develop ]
@@ -6,4 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: ./.github/actions/build
+      - uses: actions/checkout@v3
+      - run: python3 -m pip install -r requirements.txt
+      - run: ./vilf build
+

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,5 +8,5 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: python3 -m pip install -r requirements.txt
-      - run: python3 vilf.py build
+      - run: ./vilf build
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,5 +8,5 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: python3 -m pip install -r requirements.txt
-      - run: ./vilf build
+      - run: python3 vilf.py build
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,10 +4,12 @@ on:
     branches: develop
 jobs:
   deploy:
-    - uses: "${{ github.repository }}/.github/workflows/_build.yaml"
-    - uses: google-github-actions/auth@v0
-      with:
-        credentials_json: "${{ secrets.CLIMAX_VILF_SA_KEY }}"
-    - uses: google-github-actions/setup-gcloud@v0
-    - run: gsutil -m rsync -R build gs://climax-vilf-bucket
+    runs-on: ubuntu-latest
+    steps:
+	    - uses: ${{ github.repository }}/.github/workflows/_build.yaml@${{ github.ref_name }}
+	    - uses: google-github-actions/auth@v0
+	      with:
+	        credentials_json: "${{ secrets.CLIMAX_VILF_SA_KEY }}"
+	    - uses: google-github-actions/setup-gcloud@v0
+	    - run: gsutil -m rsync -R build gs://climax-vilf-bucket
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,7 +6,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-	    - uses: ${{ github.repository }}/.github/workflows/_build.yaml@${{ github.ref_name }}
+      - uses: ./.github/actions/build
 	    - uses: google-github-actions/auth@v0
 	      with:
 	        credentials_json: "${{ secrets.CLIMAX_VILF_SA_KEY }}"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,7 +4,7 @@ on:
     branches: develop
 jobs:
   deploy:
-    - uses: ${{ github.repository }}/.github/workflows/_build.yaml@${{ github.ref_name }}
+    - uses: "${{ github.repository }}/.github/workflows/_build.yaml"
     - uses: google-github-actions/auth@v0
       with:
         credentials_json: "${{ secrets.CLIMAX_VILF_SA_KEY }}"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,16 +1,10 @@
 name: Deploy VILF
 on:
-  push:
-    branches: [ develop ]
   pull_request:
-    branches: [ develop ]
+    branches: develop
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - run: python3 -m pip install -r requirements.txt
-    - run: ./vilf build
+  deploy:
+    - uses: ${{ github.repository }}/.github/workflows/_build.yaml@${{ github.ref_name }}
     - uses: google-github-actions/auth@v0
       with:
         credentials_json: "${{ secrets.CLIMAX_VILF_SA_KEY }}"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: python3 -m pip install -r requirements.txt
-      - run: ./vilf build
+      - run: python3 vilf.py build
 	    - uses: google-github-actions/auth@v0
 	      with:
 	        credentials_json: "${{ secrets.CLIMAX_VILF_SA_KEY }}"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,7 +1,8 @@
 name: Deploy VILF
 on:
   push:
-    branches: [ develop ]
+    branches:
+      - develop
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,7 +6,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: ./.github/actions/build
+      - uses: actions/checkout@v3
+      - run: python3 -m pip install -r requirements.txt
+      - run: ./vilf build
 	    - uses: google-github-actions/auth@v0
 	      with:
 	        credentials_json: "${{ secrets.CLIMAX_VILF_SA_KEY }}"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,7 +1,7 @@
 name: Deploy VILF
 on:
-  pull_request:
-    branches: develop
+  push:
+    branches: [ develop ]
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,18 +1,16 @@
 name: Deploy VILF
 on:
   push:
-    branches:
-      - develop
+    branches: develop
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - run: python3 -m pip install -r requirements.txt
-      - run: python3 vilf.py build
-	    - uses: google-github-actions/auth@v0
-	      with:
-	        credentials_json: "${{ secrets.CLIMAX_VILF_SA_KEY }}"
-	    - uses: google-github-actions/setup-gcloud@v0
-	    - run: gsutil -m rsync -R build gs://climax-vilf-bucket
-
+      - run: ./vilf build
+      - uses: google-github-actions/auth@v0
+        with:
+          credentials_json: "${{ secrets.CLIMAX_VILF_SA_KEY }}"
+      - uses: google-github-actions/setup-gcloud@v0
+      - run: gsutil -m rsync -R build gs://climax-vilf-bucket

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
 venv/
 static/img/
-scripts/__pycache__/
+*.swp
+


### PR DESCRIPTION
These changes define two github workflows:

1) Test Build VILF, which addresses [#7](https://github.com/ItsiW/VILF/issues/7), to provide testing for PR branches that merge into 'develop'
2) Deploy VILF, which addresses [#15](https://github.com/ItsiW/VILF/issues/15), to only build and deploy on changes to 'develop' branch

- dev: exclude vim .swp files from version control
- feat: run 'build' workflow on pushes to any remote branch but the 'deploy' workflow on pull requests to the 'develop' branch
- edit: fix incorrect syntax in 'build' workflow
- edit: make 'build' workflow callable from the 'deploy' workflow
- edit: try to fix syntax error in workflow file
- edit: add necessary 'steps' keyword under the 'deploy' workflow main job name (prob the syntax error)
- edit: factor build into a local action and create separate workflows for building on push and deploying on pull requests to develop
- update build action to use new command syntax
- only deploy code when changes are shown in the develop branch
- only run the test build workflow on PR branches that use develop as the target
- cicd: remove separate action file and just copy shared steps I don't think you can just take steps from other github workflows, and have them work within the same filesystem environment. Reusable workflows can only be used as separate jobs, which is not the use case.
- cicd: test out syntax change
- cicd: test out syntax change
- cicd: fix indentation
